### PR TITLE
Use MySQL for user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,27 @@
 
 ---
 
+## 🛠️ Setup
+
+1. Installiere die Abhängigkeiten mit `npm install`.
+2. Lege eine `.env` Datei mit den Datenbank-Zugangsdaten an:
+
+```
+DB_HOST=dein-host
+DB_USER=dein-user
+DB_PASSWORD=dein-passwort
+DB_DATABASE=veres
+DISCORD_TOKEN=dein-bot-token
+```
+
+Der Bot erstellt die benötigte Tabelle bei Start automatisch.
+
+---
+
 ## 🧠 Architektur
 
 - **Command Loader**: Lädt alle Slash-Commands rekursiv aus dem `commands/`-Verzeichnis
-- **Benutzerdaten**: Als JSON-Dateien unter `data/users/` gespeichert
+ - **Benutzerdaten**: Werden in einer MySQL-Datenbank gespeichert
 - **Shop & Upgrades**: Zentrale Definitionen in `utils/shopItems.js`
 - **Hilfesystem**: Dynamisch generierte Kategorieliste mit Buttons und Dropdown-Menü
 - **Effekte & Achievements**: Modular erweiterbar

--- a/commands/dev/reset.js
+++ b/commands/dev/reset.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
-const fs = require('fs');
-const path = require('path');
+const { pool, init } = require('../../utils/db');
+const { defaultData } = require('../../utils/user');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -13,8 +13,11 @@ module.exports = {
       return interaction.reply({ content: '⛔ Nicht erlaubt.', flags: 1 << 6 });
     }
 
-    const file = path.join(__dirname, '../../data/users', `${interaction.user.id}.json`);
-    fs.writeFileSync(file, JSON.stringify({ hearts: 0, coins: 0, upgrades: [], lastClaim: null }, null, 2));
+    await init();
+    await pool.query(
+      'REPLACE INTO users (id, data) VALUES (?, ?)',
+      [interaction.user.id, JSON.stringify(defaultData)]
+    );
 
     await interaction.reply({ content: '🧼 Dein Fortschritt wurde zurückgesetzt.', flags: 1 << 6 });
   },

--- a/commands/heart-game/achievements.js
+++ b/commands/heart-game/achievements.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 const { getAllAchievements } = require('../../utils/achievements');
 const { EMOJI_OK, EMOJI_ERROR } = require('../../utils/emojis');
 
@@ -10,7 +10,7 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const { data } = getUserFile(interaction.user.id);
+    const { data } = await getUser(interaction.user.id);
     const unlocked = data.achievements || {};
     const all = getAllAchievements();
 

--- a/commands/heart-game/autolove.js
+++ b/commands/heart-game/autolove.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const fs = require('fs');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 
 
 module.exports = {
@@ -11,7 +10,7 @@ module.exports = {
 
   async execute(interaction) {
     const userId = interaction.user.id;
-    const { data, file } = getUserFile(userId);
+    const { data, save } = await getUser(userId);
 
     if (!data.upgrades.includes('AutoLove')) {
       const embed = new EmbedBuilder()
@@ -44,7 +43,7 @@ module.exports = {
 
     data.hearts += 1;
     data.lastClaim = new Date().toISOString();
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    await save(data);
 
     const embed = new EmbedBuilder()
       .setAuthor({

--- a/commands/heart-game/buy.js
+++ b/commands/heart-game/buy.js
@@ -1,8 +1,7 @@
 // commands/buy.js
 
 const { SlashCommandBuilder } = require('discord.js');
-const fs = require('fs');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 const upgrades = require('../../utils/shopItems');
 
 // Emojis aus der zentralen Datei importieren:
@@ -24,7 +23,7 @@ module.exports = {
   // Autocomplete-Handler: Zeigt nur verfügbare Upgrades (level < maxLevel).
   async autocomplete(interaction) {
     const focused = interaction.options.getFocused();
-    const { data } = getUserFile(interaction.user.id);
+    const { data } = await getUser(interaction.user.id);
 
     // Sicherstellen, dass data.upgradeLevels ein Objekt ist
     data.upgradeLevels = data.upgradeLevels ?? {};
@@ -44,7 +43,7 @@ module.exports = {
   // Execute-Handler: Führt den Kauf durch (Antworten sind öffentlich sichtbar).
   async execute(interaction) {
     const name = interaction.options.getString('item');
-    const { data, file } = getUserFile(interaction.user.id);
+    const { data, save } = await getUser(interaction.user.id);
 
     // Default-Werte initialisieren
     data.coins = data.coins ?? 0;
@@ -90,8 +89,8 @@ module.exports = {
       }
     }
 
-    // In Datei speichern
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    // Daten speichern
+    await save(data);
 
     return interaction.reply({
       content: `${EMOJI_OK} Du hast **${name}** auf Level ${data.upgradeLevels[name]} gekauft!`,

--- a/commands/heart-game/daily.js
+++ b/commands/heart-game/daily.js
@@ -1,7 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const fs = require('fs');
 const { EMOJI_COIN } = require('../../utils/emojis');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 
 function getReward(streak) {
   return 50 + streak * 10; // steigert sich pro Tag
@@ -14,7 +13,7 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const { data, file } = getUserFile(interaction.user.id);
+    const { data, save } = await getUser(interaction.user.id);
     const now = Date.now();
     const last = data.lastDaily ? new Date(data.lastDaily).getTime() : 0;
 
@@ -43,7 +42,7 @@ module.exports = {
     data.coins += reward;
     data.lastDaily = new Date().toISOString();
 
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    await save(data);
 
     const embed = new EmbedBuilder()
       .setAuthor({

--- a/commands/heart-game/effects.js
+++ b/commands/heart-game/effects.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 const { getLoveDropBonus, getRareMultiplier } = require('../../utils/effects');
 
 module.exports = {
@@ -9,7 +9,7 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const { data } = getUserFile(interaction.user.id);
+    const { data } = await getUser(interaction.user.id);
     const drops = getLoveDropBonus(data);
     const mult = (getRareMultiplier(data) * 100).toFixed(1);
 

--- a/commands/heart-game/inventory.js
+++ b/commands/heart-game/inventory.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 const shopItems = require('../../utils/shopItems');
 const { EMOJI_COIN } = require('../../utils/emojis');
 
@@ -10,7 +10,7 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const { data } = getUserFile(interaction.user.id);
+    const { data } = await getUser(interaction.user.id);
     const upgrades = data.upgradeLevels ?? {};
 
     const coins = data.coins ?? 0;

--- a/commands/heart-game/leaderboard.js
+++ b/commands/heart-game/leaderboard.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const fs = require('fs');
-const path = require('path');
+const { pool, init } = require('../../utils/db');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -9,13 +8,11 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const userPath = path.join(__dirname, '../../data/users');
-    const files = fs.readdirSync(userPath).filter(f => f.endsWith('.json'));
-
-    const users = files.map(f => {
-      const userId = f.replace('.json', '');
-      const data = JSON.parse(fs.readFileSync(path.join(userPath, f)));
-      return { id: userId, coins: data.coins || 0 };
+    await init();
+    const [rows] = await pool.query('SELECT id, data FROM users');
+    const users = rows.map(r => {
+      const d = typeof r.data === 'string' ? JSON.parse(r.data) : r.data;
+      return { id: r.id, coins: d.coins || 0 };
     });
 
     const top = users.sort((a, b) => b.coins - a.coins).slice(0, 5);

--- a/commands/heart-game/love.js
+++ b/commands/heart-game/love.js
@@ -1,8 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { getLoveDropBonus, getRareMultiplier } = require('../../utils/effects');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 const { checkAchievements } = require('../../utils/achievements');
-const fs = require('fs');
 
 const heartTypes = [
   { name: 'Common', emoji: '❤️', chance: 60 },
@@ -28,7 +27,7 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const { data, file } = getUserFile(interaction.user.id);
+    const { data, save } = await getUser(interaction.user.id);
 
     const baseCount = Math.floor(Math.random() * 3) + 1;
     const bonus = getLoveDropBonus(data);
@@ -44,8 +43,8 @@ module.exports = {
       results[heart.name] = (results[heart.name] || 0) + multiplier;
     }
 
-    const unlocked = checkAchievements(interaction.user.id, data, file);
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    const unlocked = await checkAchievements(interaction.user.id, data, save);
+    await save(data);
 
     const earnedList = Object.entries(results)
       .map(([type, count]) => {

--- a/commands/heart-game/profile.js
+++ b/commands/heart-game/profile.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const fs = require('fs');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 
 const titleRoles = {
   'Anfänger der Liebe': 'Anfänger der Liebe',
@@ -24,11 +23,11 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const { data, file } = getUserFile(interaction.user.id);
+    const { data, save } = await getUser(interaction.user.id);
     const oldTitle = data.title;
     const newTitle = autoAssignTitle(data);
     data.title = newTitle; // auto-update title
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    await save(data);
 
     if (interaction.guild) {
       try {

--- a/commands/heart-game/sell.js
+++ b/commands/heart-game/sell.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const { getUserFile } = require('../../utils/user');
-const fs = require('fs');
+const { getUser } = require('../../utils/user');
 const {
   EMOJI_OK,
   EMOJI_WARN,
@@ -34,7 +33,7 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const { data, file } = getUserFile(interaction.user.id);
+    const { data, save } = await getUser(interaction.user.id);
 
     let totalCoins = 0;
     let sold = [];
@@ -54,7 +53,7 @@ module.exports = {
     }
 
     data.coins += totalCoins;
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    await save(data);
 
     const embed = new EmbedBuilder()
       .setAuthor({

--- a/commands/heart-game/shop.js
+++ b/commands/heart-game/shop.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { getUserFile } = require('../../utils/user');
+const { getUser } = require('../../utils/user');
 const {
   buildShopEmbed,
   buildInventoryEmbed,
@@ -13,7 +13,7 @@ module.exports = {
   category: 'heart-game',
 
   async execute(interaction) {
-    const { data } = getUserFile(interaction.user.id);
+    const { data } = await getUser(interaction.user.id);
 
     const shopEmbed = buildShopEmbed(data, interaction.user);
     const invEmbed = buildInventoryEmbed(data, interaction.user);

--- a/index.js
+++ b/index.js
@@ -165,17 +165,16 @@ client.on('interactionCreate', async (interaction) => {
 
     // === Shop-Buttons ===
     if (interaction.customId.startsWith('buy_')) {
-      const { getUserFile } = require('./utils/user');
+      const { getUser } = require('./utils/user');
       const shopItems = require('./utils/shopItems');
       const {
         buildShopEmbed,
         buildInventoryEmbed,
         buildShopButtons,
       } = require('./utils/shopUI');
-      const fsSync = require('fs');
 
       const name = interaction.customId.replace('buy_', '');
-      const { data, file } = getUserFile(interaction.user.id);
+      const { data, save } = await getUser(interaction.user.id);
       const item = shopItems[name];
       if (!item) return;
 
@@ -207,7 +206,7 @@ client.on('interactionCreate', async (interaction) => {
         }
       }
 
-      fsSync.writeFileSync(file, JSON.stringify(data, null, 2));
+      await save(data);
 
       const shopEmbed = buildShopEmbed(data, interaction.user);
       const invEmbed = buildInventoryEmbed(data, interaction.user);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.19.3",
-        "dotenv": "^16.5.0"
+        "dotenv": "^16.5.0",
+        "mysql2": "^3.14.1"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -201,6 +202,24 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/discord-api-types": {
       "version": "0.38.8",
       "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.8.tgz",
@@ -255,6 +274,33 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -267,11 +313,93 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
     "node_modules/magic-bytes.js": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
       "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
       "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.1.tgz",
+      "integrity": "sha512-7ytuPQJjQB8TNAYX/H2yhL+iQOnIBjAMam361R7UAL0lOVXWjtdrmoL9HYKqKoLp/8UUTRcvo1QPvK9KL7wA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "description": "**Veres** ist ein interaktiver Discord-Bot mit einem liebevoll gestalteten Herzspiel. Benutzer können Herzen sammeln, Erfolge freischalten, tägliche Belohnungen erhalten, Items kaufen, Upgrades durchführen, und sich mit anderen Spielern im Leaderboard messen. Mit hübsch gestalteten Embeds und einer durchdachten Benutzererfahrung macht Veres den Server-Alltag bunter.",
   "dependencies": {
     "discord.js": "^14.19.3",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "mysql2": "^3.14.1"
   },
   "repository": {
     "type": "git",

--- a/utils/achievements.js
+++ b/utils/achievements.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-const path = require('path');
 
 const allAchievements = {
   'Herzenssammler ': user => totalHearts(user) >= 10,
@@ -12,7 +10,7 @@ function totalHearts(user) {
   return Object.values(user.inventory || {}).reduce((a, b) => a + b, 0);
 }
 
-function checkAchievements(userId, data, file) {
+async function checkAchievements(userId, data, save) {
   if (!data.achievements) data.achievements = {};
 
   let unlocked = [];
@@ -25,7 +23,7 @@ function checkAchievements(userId, data, file) {
   }
 
   if (unlocked.length > 0) {
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    await save(data);
   }
 
   return unlocked; // für Feedback

--- a/utils/db.js
+++ b/utils/db.js
@@ -1,0 +1,19 @@
+const mysql = require('mysql2/promise');
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_DATABASE,
+});
+
+async function init() {
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS users (
+      id VARCHAR(64) PRIMARY KEY,
+      data JSON NOT NULL
+    )`
+  );
+}
+
+module.exports = { pool, init };

--- a/utils/user.js
+++ b/utils/user.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const path = require('path');
+const { pool, init } = require('./db');
 
 const defaultData = {
   inventory: { Common: 0, Rare: 0, Epic: 0, Legendary: 0 },
@@ -8,30 +7,38 @@ const defaultData = {
   lastClaim: null,
   lastDaily: null,
   streak: 0,
-  title: 'Anfänger der Liebe'
+  title: 'Anfänger der Liebe',
 };
 
-function getUserFile(userId) {
-  const file = path.join(__dirname, '../data/users', `${userId}.json`);
-
-  if (!fs.existsSync(file)) {
-    fs.writeFileSync(file, JSON.stringify(defaultData, null, 2));
+async function getUser(userId) {
+  await init();
+  const [rows] = await pool.query('SELECT data FROM users WHERE id=?', [userId]);
+  let data;
+  if (rows.length === 0) {
+    data = { ...defaultData };
+    await pool.query('INSERT INTO users (id, data) VALUES (?, ?)', [userId, JSON.stringify(data)]);
+  } else {
+    if (typeof rows[0].data === 'string') {
+      data = JSON.parse(rows[0].data);
+    } else {
+      data = rows[0].data;
+    }
   }
 
-  const data = JSON.parse(fs.readFileSync(file));
-
-  // Ergänze fehlende Felder
   for (const key in defaultData) {
     if (data[key] === undefined) data[key] = defaultData[key];
   }
-
   for (const heart in defaultData.inventory) {
     if (!data.inventory) data.inventory = {};
     if (data.inventory[heart] === undefined) data.inventory[heart] = 0;
   }
+  await pool.query('UPDATE users SET data=? WHERE id=?', [JSON.stringify(data), userId]);
 
-  fs.writeFileSync(file, JSON.stringify(data, null, 2));
-  return { data, file };
+  async function save(updated) {
+    await pool.query('UPDATE users SET data=? WHERE id=?', [JSON.stringify(updated), userId]);
+  }
+
+  return { data, save };
 }
 
-module.exports = { getUserFile };
+module.exports = { getUser, defaultData };


### PR DESCRIPTION
## Summary
- store user profiles inside a MySQL table instead of JSON files
- add database helper utility
- switch all commands to use the new `getUser` helper
- update dev reset command
- document environment variables and setup steps
- add `mysql2` dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841593f0bc88327b846a90cddc30774